### PR TITLE
Avoid fptError{}.Error() panics

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,10 +42,10 @@ type ftpError struct {
 }
 
 func (e ftpError) Error() string {
-	if e.code != 0 {
-		return fmt.Sprintf("unexpected response: %d-%s", e.code, e.msg)
-	} else {
+	if e.err != nil {
 		return e.err.Error()
+	} else {
+		return fmt.Sprintf("unexpected response: %d-%s", e.code, e.msg)
 	}
 }
 
@@ -58,14 +58,14 @@ func (e ftpError) Timeout() bool {
 }
 
 func (e ftpError) Code() int {
-	if fe, ok := e.err.(Error); ok {
+	if fe, _ := e.err.(Error); fe != nil {
 		return fe.Code()
 	}
 	return e.code
 }
 
 func (e ftpError) Message() string {
-	if fe, ok := e.err.(Error); ok {
+	if fe, _ := e.err.(Error); fe != nil {
 		return fe.Message()
 	}
 	return e.msg


### PR DESCRIPTION
Based on reports, sometimes there is a nil pointer exception in
ftpError{}. This would happen if err is nil and code is 0 (which I
didn't think was possible). I'm not sure how it happens, but re order
things to avoid the panic.